### PR TITLE
fix: correct path mistakes

### DIFF
--- a/configs/idol_debug.yaml
+++ b/configs/idol_debug.yaml
@@ -37,8 +37,8 @@ model:
     encoder:
       target: lib.models.sapiens.SapiensWrapper_ts 
       params:
-        # model_path:   work_dirs/ckpt/sapiens_1b_epoch_173_torchscript.pt2
-        model_path: /apdcephfs_cq8/share_1367250/harriswen/projects/sapiens_convert/checkpoints//sapiens_1b_epoch_173_torchscript.pt2
+        model_path:   work_dirs/ckpt/sapiens_1b_epoch_173_torchscript.pt2
+        # model_path: /apdcephfs_cq8/share_1367250/harriswen/projects/sapiens_convert/checkpoints//sapiens_1b_epoch_173_torchscript.pt2
         layer_num: 40
         img_size: [1024, 736]
         freeze: True

--- a/configs/idol_v0.yaml
+++ b/configs/idol_v0.yaml
@@ -37,8 +37,8 @@ model:
     encoder:
       target: lib.models.sapiens.SapiensWrapper_ts 
       params:
-        # model_path:   work_dirs/ckpt/sapiens_1b_epoch_173_torchscript.pt2
-        model_path: /apdcephfs_cq8/share_1367250/harriswen/projects/sapiens_convert/checkpoints//sapiens_1b_epoch_173_torchscript.pt2
+        model_path:   work_dirs/ckpt/sapiens_1b_epoch_173_torchscript.pt2
+        # model_path: /apdcephfs_cq8/share_1367250/harriswen/projects/sapiens_convert/checkpoints//sapiens_1b_epoch_173_torchscript.pt2
         layer_num: 40
         img_size: [1024, 736]
         freeze: True

--- a/env/README.md
+++ b/env/README.md
@@ -35,7 +35,7 @@ bash scripts/fetch_template.sh
 
 ### 3. Download Pretrained Models and caches with:
 ```bash
-bash env/download_files.sh      # download pretrained models
+bash scripts/download_files.sh      # download pretrained models
 ```
 
 Or mannually download the following models from HuggingFace:


### PR DESCRIPTION
Correct path to the script for downloading pretrained models in ```env/README.md```
Change model path in config files (e.g., ```configs/idol_v0.yaml```) to cached directory.